### PR TITLE
Allow `lang=` mode prefix in Markdown code blocks

### DIFF
--- a/modes/poly-markdown.el
+++ b/modes/poly-markdown.el
@@ -43,7 +43,7 @@
   (pm-hbtchunkmode-auto "markdown"
                      :head-reg "^[ \t]*```[{ \t]*\\w.*$"
                      :tail-reg "^[ \t]*```[ \t]*$"
-                     :retriever-regexp "```[ \t]*{?\\(\\(\\w\\|\\s_\\)*\\)"
+                     :retriever-regexp "```[ \t]*\\(?:{\\|lang=\\)?\\(\\(\\w\\|\\s_\\)*\\)"
                      :font-lock-narrow t)
   "Markdown typical chunk."
   :group 'innermodes


### PR DESCRIPTION
This is required by the Markdown variant used by Phabricator
(see https://secure.phabricator.com/book/phabricator/article/remarkup/).