### PR TITLE
Escape special characters to prevent shell errors

### DIFF
--- a/polymode-export.el
+++ b/polymode-export.el
@@ -92,9 +92,10 @@
                                 (file-name-base ifile))
                         "." (nth 1 to-spec)))
          (command (format-spec (nth 3 from-spec)
-                               (list (cons ?i ifile)
-                                     (cons ?o ofile)
-                                     (cons ?O (file-name-base ofile))
+                               (list (cons ?i (shell-quote-argument ifile))
+                                     (cons ?o (shell-quote-argument ofile))
+                                     (cons ?O (shell-quote-argument
+                                               (file-name-base ofile)))
                                      (cons ?t (nth 3 to-spec))))))
     (unless to-spec
       (error "'to' spec %s is not defined for this exporter '%s'"


### PR DESCRIPTION
By default, woven and exported file names take the form name[woven].tex
and name[woven][exported].pdf. Without quoting these names, the shell
will try to interpret the special characters and return errors like the
one below.

        Exporting latex-->pdf with command:
        latexmk -jobname=bootstrap_paper\[woven\][exported] -pdf \
        bootstrap_paper\[woven\].tex

        zsh:1: no matches found:
        -jobname=bootstrap_paper[woven][exported]

Calling (shell-quote-argument) on the arguments of the export command
prevents such errors.