### PR TITLE
bug in pm--display-file

### DIFF
--- a/polymode-core.el
+++ b/polymode-core.el
@@ -309,7 +309,7 @@ near future.")
             (with-current-buffer buff
               (revert-buffer t t)))
           (when polymode-display-output-file
-            (if (string-match-p "html\\|htm$")
+            (if (string-match-p "html\\|htm$" ofile)
                 (browse-url ofile)
               (display-buffer (find-file-noselect ofile 'nowarn)))))
       (error (message "Error while displaying '%s': %s"


### PR DESCRIPTION
The function `pm--display-file` includes a call to `(string-match-p "html\\htm$")`. This is a syntax error, as `string-match-p` takes two arguments. I think the second argument here should be `ofile`. This means `string-match-p` tests if the output file is html, and if so opens it with a browser. The else clause opens non-html files with `(display-buffer ...)`.

This bit of code is wrapped in `(condition-case err ...)`, and so the error from `string-match-p` is presented to the user as a problem displaying the file, which is a bit of a misdirection.

Best,

Tyler