### PR TITLE
Better integration of poly-org-mode with sub-modes

### DIFF
--- a/modes/poly-org.el
+++ b/modes/poly-org.el
@@ -76,8 +76,8 @@ to be able to find the process buffer associated with the current code block."
 				hostbuf 'org-outline-level)))))
 
 ;; Run `poly-org-mode-fix-outlines' whenever we navigate into a code block in org-mode.
-(add-hook 'polymode-switch-buffer-hook #'poly-org-fix-outlines)
-;;(remove-hook 'polymode-switch-buffer-hook #'poly-org-fix-outlines)
+(add-hook 'polymode-switch-buffer-hook #'poly-org-mode-fix-outlines)
+;;(remove-hook 'polymode-switch-buffer-hook #'poly-org-mode-fix-outlines)
 
 (defun poly-org-mode-process-buffer-name (&optional a b c d e)
   "Return the name of the process buffer associated with the current babel block.
@@ -113,7 +113,5 @@ advised by this function. This function will not work properly unless `outline-r
 (if (featurep 'python-mode)
     (advice-add 'py--choose-buffer-name :before-until #'poly-org-mode-process-buffer-name))
 ;;(advice-remove 'ess-get-process #'poly-org-mode-process-buffer-name)
-
-
 
 (provide 'poly-org)

--- a/modes/poly-org.el
+++ b/modes/poly-org.el
@@ -63,5 +63,57 @@
 ;;;###autoload  (autoload 'poly-org-mode "poly-org")
 (define-polymode poly-org-mode pm-poly/org)
 
-(provide 'poly-org)
+(defun poly-org-mode-fix-outlines (oldbuf newbuf)
+  "Set `outline-regexp' and `outline-level' in sub-modes of `poly-org-mode'.
+This makes navigation easier, and is required in order for `poly-org-mode-process-buffer-name'
+to be able to find the process buffer associated with the current code block."
+  (let* ((host (oref pm/polymode -hostmode))
+	 (hostbuf (oref host -buffer)))
+    (if (eq (oref host :mode) 'org-mode)
+	(setq outline-regexp (with-current-buffer
+				 hostbuf outline-regexp)
+	      outline-level (with-current-buffer
+				hostbuf 'org-outline-level)))))
 
+;; Run `poly-org-mode-fix-outlines' whenever we navigate into a code block in org-mode.
+(add-hook 'polymode-switch-buffer-hook #'poly-org-fix-outlines)
+;;(remove-hook 'polymode-switch-buffer-hook #'poly-org-fix-outlines)
+
+(defun poly-org-mode-process-buffer-name (&optional a b c d e)
+  "Return the name of the process buffer associated with the current babel block.
+A, B, C, D, & E are placeholder arguments for compatibility with functions that are
+advised by this function. This function will not work properly unless `outline-regexp',
+ and `outline-level' are set correctly."
+  (let ((cntx (org-element-context)))
+    (if (memq (org-element-type cntx) '(inline-src-block src-block))
+	(let* ((lang (org-element-property :language cntx))
+	       (params (mapcar (lambda (s) (if (equal (substring s 0 1) ":")
+					       (intern s)
+					     s))
+			       (split-string (org-element-property :parameters cntx) " " t)))
+	       (session (plist-get params :session))
+	       (dir (plist-get params :dir))
+	       (kernel (plist-get params :kernel))
+	       (default-directory
+		 (or (and dir (file-name-as-directory dir)) default-directory))
+	       (init-cmd (intern (format "org-babel-%s-initiate-session" lang)))
+	       buf)
+	  (when (and (stringp session) (string= session "none"))
+	    (error "This block is not using a session!"))
+	  (unless (fboundp init-cmd)
+	    (error "No org-babel-initiate-session function for %s!" lang))
+	  (setq buf (funcall init-cmd session (if kernel (list (cons :kernel kernel)))))
+	  (if (bufferp buf) (buffer-name buf) buf)))))
+
+;; Make sure that ess and python sub-modes are able to find the process buffer associated
+;; with the code block.
+(if (featurep 'ess)
+    (advice-add 'ess-get-process :before-until #'poly-org-mode-process-buffer-name))
+;;(advice-remove 'py--choose-buffer-name #'poly-org-mode-process-buffer-name)
+(if (featurep 'python-mode)
+    (advice-add 'py--choose-buffer-name :before-until #'poly-org-mode-process-buffer-name))
+;;(advice-remove 'ess-get-process #'poly-org-mode-process-buffer-name)
+
+
+
+(provide 'poly-org)


### PR DESCRIPTION
With this code `poly-org-mode` sub-mode buffers can now find their respective process buffers so we can use commands such as `ess-switch-to-inferior-or-script-buffer` and `ess-eval-region-or-line-and-step` from within the `org-mode` buffer.