### PR TITLE
Drop unnecessary inhibition flags in pm--move-overlays

### DIFF
--- a/polymode-core.el
+++ b/polymode-core.el
@@ -1139,8 +1139,6 @@ switch."
                         (overlay-get o 'yas--snippet)
                         (memq (overlay-get o 'face) '(region show-paren-match)))
               (let ((o-copy (copy-overlay o))
-		    (inhibit-redisplay t)
-		    (inhibit-modification-hooks t)
                     (start (overlay-start o))
                     (end (overlay-end o)))
                 (move-overlay o-copy start end  to-buffer))))


### PR DESCRIPTION
- Stefan Monnier (https://github.com/monnier) told me that those inhibitions do nothing to help with screen flickering I saw, while I worked on polymode unfolding issue

- I tested the fix for unfolding without those 2 lines, and saw no issues

- Full discussion link: https://lists.gnu.org/archive/html/emacs-devel/2025-05/msg00614.html