### PR TITLE
pm-get-mode-symbol-from-name: make use of major-mode-remap and support -ts-mode

### DIFF
--- a/polymode-compat.el
+++ b/polymode-compat.el
@@ -69,6 +69,17 @@ Elements of ALIST that are not conses are ignored."
     (assoc-delete-all key alist #'eq)))
 
 
+;;; emacs 30
+(unless (fboundp 'major-mode-remap)
+  (defvar major-mode-remap-alist nil)
+  (defvar major-mode-remap-defaults nil)
+  (defalias 'major-mode-remap
+    (lambda (mode)
+      "Return the function to use to enable MODE."
+      (or (cdr (or (assq mode major-mode-remap-alist)
+                   (assq mode major-mode-remap-defaults)))
+          mode))))
+
 
 ;;; Various Wrappers for Around Advice
 

--- a/polymode-core.el
+++ b/polymode-core.el
@@ -1973,29 +1973,30 @@ Return FALLBACK if non-nil, otherwise the value of
             (mname (if (string-match-p "-mode$" str)
                        str
                      (concat str "-mode"))))
-       (or
-        ;; direct search
-        (let ((mode (intern mname)))
-          (when (and (fboundp mode) (functionp mode))
-            mode))
-        ;; downcase
-        (let ((mode (intern (downcase mname))))
-          (when (and (fboundp mode) (functionp mode))
-            mode))
-        ;; auto-mode alist
-        (let ((dummy-file (concat "a." str)))
-          (cl-loop for (k . v) in auto-mode-alist
-                   if (and (string-match-p k dummy-file)
-                           (not (string-match-p "^poly-" (symbol-name v))))
-                   return v))
-        (when (or (eq polymode-default-inner-mode 'host)
-                  (and (fboundp polymode-default-inner-mode)
-                       (functionp polymode-default-inner-mode)))
-          polymode-default-inner-mode)
-        (when (or (eq fallback 'host)
-                  (and (fboundp fallback) (functionp fallback)))
-          fallback)
-        'poly-fallback-mode))))))
+       (major-mode-remap
+        (or
+         ;; direct search
+         (let ((mode (intern mname)))
+           (when (and (fboundp mode) (functionp mode))
+             mode))
+         ;; downcase
+         (let ((mode (intern (downcase mname))))
+           (when (and (fboundp mode) (functionp mode))
+             mode))
+         ;; auto-mode alist
+         (let ((dummy-file (concat "a." str)))
+           (cl-loop for (k . v) in auto-mode-alist
+                    if (and (string-match-p k dummy-file)
+                            (not (string-match-p "^poly-" (symbol-name v))))
+                    return v))
+         (when (or (eq polymode-default-inner-mode 'host)
+                   (and (fboundp polymode-default-inner-mode)
+                        (functionp polymode-default-inner-mode)))
+           polymode-default-inner-mode)
+         (when (or (eq fallback 'host)
+                   (and (fboundp fallback) (functionp fallback)))
+           fallback)
+         'poly-fallback-mode)))))))
 
 (defun pm--oref-with-parents (object slot)
   "Merge slots SLOT from the OBJECT and all its parent instances."


### PR DESCRIPTION
Support the new `treesit` major mode and the `major-mode-remap` redirection function for deciding the major mode in the inner buffer