### PR TITLE
Use define-keymap instead of obsolete easy-mmode-define-keymap

### DIFF
--- a/polymode.el
+++ b/polymode.el
@@ -619,7 +619,7 @@ most frequently used slots are:
                                      (eieio-oref parent-conf '-minor-mode))))
                                   ;; 3. nil
                                   (t polymode-minor-mode-map)))))
-               (easy-mmode-define-keymap keymap nil nil (list :inherit parent-map))))
+               (apply #'define-keymap :parent parent-map keymap)))
            ,(format "Keymap for %s." mode-name))
 
 


### PR DESCRIPTION
Fixes byte-compiler warning:

Warning: `easy-mmode-define-keymap' is an obsolete function (as of 29.1); use `define-keymap' instead.

(Untested)