### PR TITLE
Revert "Use define-keymap instead of obsolete easy-mmode-define-keymap"

### DIFF
--- a/polymode.el
+++ b/polymode.el
@@ -619,7 +619,7 @@ most frequently used slots are:
                                      (eieio-oref parent-conf '-minor-mode))))
                                   ;; 3. nil
                                   (t polymode-minor-mode-map)))))
-               (apply #'define-keymap :parent parent-map keymap)))
+               (easy-mmode-define-keymap keymap nil nil (list :inherit parent-map))))
            ,(format "Keymap for %s." mode-name))
 
 


### PR DESCRIPTION
Reverts polymode/polymode#359