### PR TITLE
Fix define-keymap use

### DIFF
--- a/polymode.el
+++ b/polymode.el
@@ -601,25 +601,27 @@ most frequently used slots are:
          (defvar ,keymap-name
            (if (keymapp keymap)
                keymap
-             (let ((parent-map (unless (keymapp keymap)
-                                 ;; keymap is either nil or a list
-                                 (cond
-                                  ;; 1. if parent is config object, merge all list
-                                  ;; keymaps from parents
-                                  ((eieio-object-p (symbol-value parent))
-                                   (let ((klist.kmap (pm--get-keylist.keymap-from-parent
-                                                      keymap (symbol-value parent))))
-                                     (setq keymap (append keylist (car klist.kmap)))
-                                     (cdr klist.kmap)))
-                                  ;; 2. If parent is polymode function, take the
-                                  ;; minor-mode from the parent config
-                                  (parent
-                                   (symbol-value
-                                    (derived-mode-map-name
-                                     (eieio-oref parent-conf '-minor-mode))))
-                                  ;; 3. nil
-                                  (t polymode-minor-mode-map)))))
-               (apply #'define-keymap :parent parent-map keymap)))
+             (let* ((parent-map
+                     ;; keymap is either nil or a list
+                     (cond
+                      ;; 1. if parent is config object, merge all list
+                      ;; keymaps from parents
+                      ((eieio-object-p (symbol-value parent))
+                       (let ((klist.kmap (pm--get-keylist.keymap-from-parent
+                                          keymap (symbol-value parent))))
+                         (setq keymap (append keylist (car klist.kmap)))
+                         (cdr klist.kmap)))
+                      ;; 2. If parent is polymode function, take the
+                      ;; minor-mode from the parent config
+                      (parent
+                       (symbol-value
+                        (derived-mode-map-name
+                         (eieio-oref parent-conf '-minor-mode))))
+                      ;; 3. nil
+                      (t polymode-minor-mode-map)))
+                    (bindings (mapcan (lambda (pair) (list (car pair) (cdr pair)))
+                                      keymap)))
+               (apply #'define-keymap :parent parent-map bindings)))
            ,(format "Keymap for %s." mode-name))
 
 


### PR DESCRIPTION
Commit 4604f55cc020c75562526fb76b723e5e242c97c0 replaced easy-mmode-define-keymap (obsolete) with define-keymap (its documented replacement), but missed that easy-mode-define-keymap takes bindings as an alist while define-keymap wants a plist.

Convert from one to the other (and drop an unnecessary check while I'm there: the `if` checked the same condition).

This might still break something: define-keymap requires keys and definitions valid according to keymap-set, while
easy-mmode-define-keymap handled a few other things, either directly or via define-key. But at first glance poly-noweb (the polymode that broke after the previous commit) does not use these features, so this may be good enough.

Tested that poly-r+c++-mode initializes and that poly-noweb-electric-< is bound to "<" in poly-noweb-mode-map.